### PR TITLE
Added distro to backup meta and site archive manifest

### DIFF
--- a/includes/filters.utils.inc
+++ b/includes/filters.utils.inc
@@ -183,8 +183,10 @@ class backup_migrate_filter_utils extends backup_migrate_filter {
   function add_file_info($file, $settings) {
     $file->file_info['description']       = $settings->filters['utils_description'];
     $file->file_info['datestamp']         = time();
-    $file->file_info['generator']         = 'Backup and Migrate (http://drupal.org/project/backup_migrate)';
+    $file->file_info['generator']         = 'Backup and Migrate for Backdrop (https://github.com/backdrop-contrib/backup_migrate)';
     $file->file_info['generatorversion']  = BACKUP_MIGRATE_VERSION;
+    $file->file_info['distro']            = 'Backdrop';
+    $file->file_info['distroversion']     = VERSION;
     $file->file_info['siteurl']           = url('', array('absolute' => TRUE));
     $file->file_info['sitename']          = config_get('system.core','site_name');
     $file->file_info['drupalversion']     = VERSION;

--- a/includes/sources.archivesource.inc
+++ b/includes/sources.archivesource.inc
@@ -131,8 +131,10 @@ class backup_migrate_files_destination_archivesource extends backup_migrate_dest
       'Global' => array(
         'datestamp' => time(),
         'formatversion' => '2011-07-02',
-        'generator' => 'Backup and Migrate (http://drupal.org/project/backup_migrate)',
+        'generator'     => 'Backup and Migrate for Backdrop (https://github.com/backdrop-contrib/backup_migrate)',
         'generatorversion' => BACKUP_MIGRATE_VERSION, 
+        'distro'        => 'Backdrop',
+        'distroversion' => VERSION,
       ),
       'Site 0' => array(
         'version' => VERSION,


### PR DESCRIPTION
Helps distinguish Backdrup backups from Drupal backups. This change
needs to be made to the Drupal version as well.

The name 'distro' isn't totally accurate but that's the precedent set by the original Site Archive format:

https://groups.drupal.org/node/106754

I'm not aware of any other consumers or generators that use this variable so we should be safe enough doing this.
