### PR TITLE
Issue #80. Check if $ftp->__conn is empty before attempting ftp_systype

### DIFF
--- a/includes/destinations.ftp.inc
+++ b/includes/destinations.ftp.inc
@@ -185,7 +185,7 @@ function backdrop_ftp_connected(&$ftp) {
     return FALSE;
   }
 
-  if (!@ftp_systype($ftp->__conn)) {
+  if (empty($ftp->__conn) || !@ftp_systype($ftp->__conn)) {
     // The connection is dead
     return FALSE;
   }


### PR DESCRIPTION
Fixes #80